### PR TITLE
Overwrite default value of qt path if in env

### DIFF
--- a/qt_configure.bzl
+++ b/qt_configure.bzl
@@ -35,7 +35,11 @@ def qt_autoconf_impl(repository_ctx):
         default_qt_path = "C:\\\\Qt\\\\5.15.2\\\\msvc2019_64\\\\"
         # Overwrite default with value for Qt5_DIR env variable if it exists.
         qt5_dir_env = _get_env_var(repository_ctx, "Qt5_Dir", None)
+        print("Value of Qt5_Dir var: ", qt5_dir_env)
+        print("Value of Qt5_DIR var: ", _get_env_var(repository_ctx, "Qt5_Dir", None))
+        print("Value of all env vars: ", repository_ctx.os.environ)
         if qt5_dir_env:
+            print("in here")
             default_qt_path = qt5_dir_env
         # If predefined path does not exist search for an alternative e.g. "C:\\\\Qt\\\\5.12.10\\\\msvc2019_64\\\\"
         if not repository_ctx.path(default_qt_path).exists:

--- a/qt_configure.bzl
+++ b/qt_configure.bzl
@@ -35,9 +35,6 @@ def qt_autoconf_impl(repository_ctx):
         default_qt_path = "C:\\\\Qt\\\\5.15.2\\\\msvc2019_64\\\\"
         # Overwrite default with value for Qt5_DIR env variable if it exists.
         qt5_dir_env = _get_env_var(repository_ctx, "Qt5_Dir", None)
-        print("Value of Qt5_Dir var: ", qt5_dir_env)
-        print("Value of Qt5_DIR var: ", _get_env_var(repository_ctx, "Qt5_Dir", None))
-        print("Value of all env vars: ", repository_ctx.os.environ)
         if qt5_dir_env:
             print("in here")
             default_qt_path = qt5_dir_env

--- a/qt_configure.bzl
+++ b/qt_configure.bzl
@@ -34,7 +34,7 @@ def qt_autoconf_impl(repository_ctx):
         # Inside this folder, in Windows you can find include, lib and bin folder
         default_qt_path = "C:\\\\Qt\\\\5.15.2\\\\msvc2019_64\\\\"
         # Overwrite default with value for Qt5_DIR env variable if it exists.
-        qt5_dir_env = _get_env_var(repository_ctx, "Qt5_DIR", None)
+        qt5_dir_env = _get_env_var(repository_ctx, "Qt5_Dir", None)
         if qt5_dir_env:
             default_qt_path = qt5_dir_env
         # If predefined path does not exist search for an alternative e.g. "C:\\\\Qt\\\\5.12.10\\\\msvc2019_64\\\\"

--- a/qt_configure.bzl
+++ b/qt_configure.bzl
@@ -36,7 +36,6 @@ def qt_autoconf_impl(repository_ctx):
         # Overwrite default with value for Qt5_DIR env variable if it exists.
         qt5_dir_env = _get_env_var(repository_ctx, "Qt5_Dir", None)
         if qt5_dir_env:
-            print("in here")
             default_qt_path = qt5_dir_env
         # If predefined path does not exist search for an alternative e.g. "C:\\\\Qt\\\\5.12.10\\\\msvc2019_64\\\\"
         if not repository_ctx.path(default_qt_path).exists:

--- a/qt_configure.bzl
+++ b/qt_configure.bzl
@@ -33,6 +33,10 @@ def qt_autoconf_impl(repository_ctx):
     if os_name.find("windows") != -1:
         # Inside this folder, in Windows you can find include, lib and bin folder
         default_qt_path = "C:\\\\Qt\\\\5.15.2\\\\msvc2019_64\\\\"
+        # Overwrite default with value for Qt5_DIR env variable if it exists.
+        qt5_dir_env = _get_env_var(repository_ctx, "Qt5_DIR", None)
+        if qt5_dir_env:
+            default_qt_path = qt5_dir_env
         # If predefined path does not exist search for an alternative e.g. "C:\\\\Qt\\\\5.12.10\\\\msvc2019_64\\\\"
         if not repository_ctx.path(default_qt_path).exists:
             win_path_env = _get_env_var(repository_ctx, "PATH")


### PR DESCRIPTION
In github actions, the path of qt may not necessarily be hardcoded to `C:\...`. So if the qt5_dir env variable is set then we use that as default first and foremost.