### PR TITLE
Add QTConcurrent, Multimedia libraries and strip include prefix

### DIFF
--- a/qt.BUILD
+++ b/qt.BUILD
@@ -9,8 +9,8 @@ QT_LIBRARIES = [
     ("qml_models", "QtQmlModels", "Qt5QmlModels", []),
     ("gui", "QtGui", "Qt5Gui", [":qt_core"]),
     ("opengl", "QtOpenGL", "Qt5OpenGL", []),
-    ("multimedia", "QtMultiMedia", "Qt5MultiMedia", []),
-    ("multimediawidgets", "QtMultiMediaWidgets", "Qt5MultiMediaWidgets", []),
+    ("multimedia", "QtMultimedia", "Qt5Multimedia", []),
+    ("multimediawidgets", "QtMultimediaWidgets", "Qt5MultimediaWidgets", []),
 ]
 
 [

--- a/qt.BUILD
+++ b/qt.BUILD
@@ -9,6 +9,7 @@ QT_LIBRARIES = [
     ("qml_models", "QtQmlModels", "Qt5QmlModels", []),
     ("gui", "QtGui", "Qt5Gui", [":qt_core"]),
     ("opengl", "QtOpenGL", "Qt5OpenGL", []),
+    ("multimedia", "QtMultiMedia", "Qt5MultiMedia", []),
 ]
 
 [

--- a/qt.BUILD
+++ b/qt.BUILD
@@ -11,6 +11,7 @@ QT_LIBRARIES = [
     ("opengl", "QtOpenGL", "Qt5OpenGL", []),
     ("multimedia", "QtMultimedia", "Qt5Multimedia", []),
     ("multimediawidgets", "QtMultimediaWidgets", "Qt5MultimediaWidgets", []),
+    ("concurrent", "QtConcurrent", "Qt5Concurrent", []),
 ]
 
 [

--- a/qt.BUILD
+++ b/qt.BUILD
@@ -17,6 +17,7 @@ QT_LIBRARIES = [
         # When being on Windows this glob will be empty
         hdrs = glob(["%s/**" % include_folder], allow_empty = True),
         includes = ["."],
+        strip_include_prefix = "%s/" % include_folder,
         linkopts = ["-l%s" % library_name],
         # Available from Bazel 4.0.0
         # target_compatible_with = ["@platforms//os:linux"],
@@ -43,6 +44,7 @@ QT_LIBRARIES = [
         # When being on Linux or macOS this glob will be empty
         hdrs = glob(["include/%s/**" % include_folder], allow_empty = True),
         includes = ["include"],
+        strip_include_prefix = "%s/" % include_folder,
         # Available from Bazel 4.0.0
         # target_compatible_with = ["@platforms//os:windows"],
         deps = [":qt_%s_windows_import" % name],
@@ -56,6 +58,7 @@ QT_LIBRARIES = [
         # When being on Windows or Linux this glob will be empty
         hdrs = glob(["%s/**" % include_folder], allow_empty = True),
         includes = ["."],
+        strip_include_prefix = "%s/" % include_folder,
         linkopts = ["-F/usr/local/opt/qt5/lib"] + [
             "-framework %s" % library_name.replace("5", "") # macOS qt libs do not contain a 5 - e.g. instead of Qt5Core the lib is called QtCore
             ],

--- a/qt.BUILD
+++ b/qt.BUILD
@@ -44,7 +44,7 @@ QT_LIBRARIES = [
         # When being on Linux or macOS this glob will be empty
         hdrs = glob(["include/%s/**" % include_folder], allow_empty = True),
         includes = ["include"],
-        strip_include_prefix = "%s/" % include_folder,
+        strip_include_prefix = "include/%s/" % include_folder,
         # Available from Bazel 4.0.0
         # target_compatible_with = ["@platforms//os:windows"],
         deps = [":qt_%s_windows_import" % name],

--- a/qt.BUILD
+++ b/qt.BUILD
@@ -10,6 +10,7 @@ QT_LIBRARIES = [
     ("gui", "QtGui", "Qt5Gui", [":qt_core"]),
     ("opengl", "QtOpenGL", "Qt5OpenGL", []),
     ("multimedia", "QtMultiMedia", "Qt5MultiMedia", []),
+    ("multimediawidgets", "QtMultiMediaWidgets", "Qt5MultiMediaWidgets", []),
 ]
 
 [


### PR DESCRIPTION
Added more qt libraries. Also stripped the include prefix for each module, so instead of
```c++
#include <QtSomething/Foo>
```
we can now do
```c++
#include <Foo>
```