### PR TITLE
Create qt_resource_file rule

### DIFF
--- a/qt.bzl
+++ b/qt.bzl
@@ -139,6 +139,7 @@ def qt_resource_file(name, qrc_file, **kwargs):
 
 def qt_resource(name, files, **kwargs):
     """Creates a cc_library containing the contents of all input files using qt's `rcc` tool.
+
     Args:
       name: rule name
       files: a list of files to be included in the resource bundle

--- a/qt.bzl
+++ b/qt.bzl
@@ -109,13 +109,13 @@ genqrc = rule(
     },
 )
 
-def qt_resource_file(name, qrc_file, **kwargs):
+def qt_resource_file(name, qrc_file, files, **kwargs):
     """Creates a cc_library by running `rcc` on an existing qrc file.
 
     Args:
       name: rule name
       qrc_file: the .qrc file
-      resource_name: name of the resource. Ex: 
+      files: list of resource files referenced by the qrc.
       kwargs: extra args to pass to the cc_library
     """
     # every resource cc_library that is linked into the same binary needs a
@@ -126,7 +126,7 @@ def qt_resource_file(name, qrc_file, **kwargs):
         name = name + "_gen",
         resource_name = qrc_file.split(".")[0],
         # not relevant in this context.
-        files = [],
+        files = files,
         qrc = qrc_file,
         cpp = outfile,
     )

--- a/qt.bzl
+++ b/qt.bzl
@@ -111,13 +111,12 @@ genqrc = rule(
     },
 )
 
-def qt_resource_file(name, qrc_file, files, **kwargs):
+def qt_resource_file(name, qrc_file, **kwargs):
     """Creates a cc_library by running `rcc` on an existing qrc file.
 
     Args:
       name: rule name
       qrc_file: the .qrc file
-      files: list of resource files referenced by the qrc.
       kwargs: extra args to pass to the cc_library
     """
     # every resource cc_library that is linked into the same binary needs a
@@ -128,7 +127,7 @@ def qt_resource_file(name, qrc_file, files, **kwargs):
         name = name + "_gen",
         resource_name = qrc_file.split(".")[0],
         # not relevant in this context.
-        files = files,
+        files = [],
         qrc = qrc_file,
         cpp = outfile,
     )

--- a/qt.bzl
+++ b/qt.bzl
@@ -109,17 +109,14 @@ genqrc = rule(
     },
 )
 
-def qt_resource(name, files, **kwargs):
-    """Creates a cc_library containing the contents of all input files using qt's `rcc` tool.
+def qt_resource_file(name, qrc_file, **kwargs):
+    """Creates a cc_library by running `rcc` on an existing qrc file.
 
     Args:
       name: rule name
-      files: a list of files to be included in the resource bundle
+      qrc_file: the .qrc file
       kwargs: extra args to pass to the cc_library
     """
-    qrc_file = name + "_qrc.qrc"
-    genqrc(name = name + "_qrc", files = files, qrc = qrc_file)
-
     # every resource cc_library that is linked into the same binary needs a
     # unique 'name'.
     rsrc_name = native.package_name().replace("/", "_") + "_" + name
@@ -136,6 +133,23 @@ def qt_resource(name, files, **kwargs):
         name = name,
         srcs = [outfile],
         alwayslink = 1,
+        **kwargs
+    )
+
+def qt_resource(name, files, **kwargs):
+    """Creates a cc_library containing the contents of all input files using qt's `rcc` tool.
+
+    Args:
+      name: rule name
+      files: a list of files to be included in the resource bundle
+      kwargs: extra args to pass to the cc_library
+    """
+    qrc_file = name + "_qrc.qrc"
+    genqrc(name = name + "_qrc", files = files, qrc = qrc_file)
+
+    qt_resource_file(
+        name = name,
+        qrc_file = qrc_file,
         **kwargs
     )
 

--- a/qt.bzl
+++ b/qt.bzl
@@ -73,6 +73,8 @@ def _gencpp(ctx):
         outputs = [ctx.outputs.cpp],
         arguments = args,
         executable = info.rcc_path,
+        # Run RCC outside the sandbox since it sometimes seems to not find files.
+        execution_requirements = { 'no-sandbox': '1' }
     )
     return [OutputGroupInfo(cpp = depset([ctx.outputs.cpp]))]
 


### PR DESCRIPTION
Similar to existing qt_resource rule, but allows user to specify an existing qrc file which should be used.